### PR TITLE
Fixes parent attribute getter in Page class

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -359,7 +359,7 @@ class Page extends QueryableModel implements Responsable
    */
   public function getParentAttribute()
   {
-    return static::find($this->parent_id);
+    return static::find((int) $this->parent_id);
   }
 
   /**


### PR DESCRIPTION
The `getParentAttribute()` calls `find()` with the `$parent_id` as a string. This does not work, as `find()` does an identical comparison to an integer. This fix casts the `$parent_id` to an integer in `getParentAttribute()`.