### PR TITLE
Adds field definition for EditorButton with type text

### DIFF
--- a/src/Components/EditorButton.php
+++ b/src/Components/EditorButton.php
@@ -65,6 +65,7 @@ class EditorButton extends Component
             case 'color':
             case 'select':
             case 'multiselect':
+            case 'text':
               $this->field = 'text';
               break;
             case 'image':


### PR DESCRIPTION
This fixes EditorButton with type text not saving its contents because of missing field definition. This should probably be checked out for other types too.