### PR TITLE
Fix stray tags being created when tag is not specified.

### DIFF
--- a/src/views/inline.blade.php
+++ b/src/views/inline.blade.php
@@ -16,10 +16,10 @@
     @endisset
 @overwrite
 
-@isset($tag)
-    <{{ $tag }} @yield('attributes')>
+@if($tag() !== null)
+    <{{ $tag() }} @yield('attributes')>
 @endif
     {!! $value ?? null !!}
-@isset($tag)
-    </{{ $tag }}>
+@if($tag() !== null)
+    </{{ $tag() }}>
 @endif


### PR DESCRIPTION
Due to there both being a `$this->tag` and `function tag()` in the component, the `@isset($tag)`code would always return true as the `$tag` variable exposed in the blade template would be the declared function.

This would make the component return an invalid tag that would be visible before the x-inline tags.
This PR fixes this issue