### PR TITLE
Fixes text content fetched from wrong column

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -385,7 +385,7 @@ if (!function_exists('map_content')) {
         return null;
       case 'text':
         if ($item = $content->shift()) {
-          return $item->html ?? null;
+          return $item->text ?? null;
         }
 
         return null;


### PR DESCRIPTION
[b67ac49](https://github.com/netflex-sdk/pages/commit/b67ac49095467433d6e6f0a1050bd277859b3511) introduced a bug where page content of type text would get it's value from the html column rather than text column.
This reverts the column name, while leaving the original intent of the commit.