### PR TITLE
Revert text field type

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -385,7 +385,7 @@ if (!function_exists('map_content')) {
         return null;
       case 'text':
         if ($item = $content->shift()) {
-          return $item->html ?? null;
+          return $item->text ?? null;
         }
 
         return null;


### PR DESCRIPTION
The content helper was changed removing an automatic cast to HtmlString in a recent commit. When this was removed the content field it selects data from was changed from `text` to `html`.

Correct value is `text`