### PR TITLE
Generate twitter card type meta tag

### DIFF
--- a/src/Components/Seo.php
+++ b/src/Components/Seo.php
@@ -12,28 +12,30 @@ class Seo extends Component
     public $images = [];
     public $canonical;
     public $suffix = false;
+    public $cardType;
 
-    public function __construct($title = null, $description = null, $images = [], $canonical = null, $suffix = true)
+    public function __construct($title = null, $description = null, $images = [], $canonical = null, $suffix = true, $cardType = 'summary')
     {
         $this->title = $title;
         $this->description = $description;
         $this->images = $images;
         $this->canonical = $canonical;
         $this->suffix = $suffix;
+        $this->cardType = $cardType;
     }
 
     public function tags () {
 
         if ($page = current_page()) {
-            
+
             if(SEOTools::getTitle() === SEOTools::metatags()->getDefaultTitle()) {
                 SEOTools::setTitle($page->title, $this->suffix);
             }
-            
+
             if(!SEOTools::metatags()->getDescription()) {
                 SEOTools::setDescription($page->description);
             }
-                
+
         }
 
         if ($this->title) {
@@ -51,6 +53,8 @@ class Seo extends Component
         if ($this->canonical) {
             SEOTools::setCanonical($this->canonical);
         }
+
+        SEOTools::twitter()->settype($this->cardType);
 
         return SEOTools::generate();
     }


### PR DESCRIPTION
 If no argument is passed to component constructor a default card is generated.

Card type can be passed as a string when calling component with <x-seo cardType="cardtype" />.
Uses card type 'summary' as default.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix: Generate twitter card meta tag by default, so content is sharable on twitter.

* **What is the current behavior?** (You can also link to an open issue here)
Does not output card meta tag that is recognized by twitter.
Outputs a tag <meta name="twitter:defaults:card" content="summary"> which does not seem to work.


* **What is the new behavior (if this is a feature change)?**
outputs <meta name="twitter:card" content="summary">


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Only adds another meta tag, and leaves previous tags in. Should not break anything


* **Other information**:
