### PR TITLE
Bugfixes in sitemap

### DIFF
--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -322,7 +322,7 @@ class RouteServiceProvider extends ServiceProvider
   protected function mapSitemap()
   {
     Route::get('/sitemap.xml', function () {
-      $entries = [];
+      $entries = $this->getSitemapEntries();
 
       return response(view('nf::sitemap-xml', ['entries' => $entries]), 200, ['Content-Type' => 'application/xml']);
     })->name('Sitemap');
@@ -330,5 +330,10 @@ class RouteServiceProvider extends ServiceProvider
     Route::get('/sitemap.xsl', function () {
       return response(view('nf::sitemap-xsl'), 200, ['Content-Type' => 'text/xsl']);
     })->name('Sitemap Stylsheet');
+  }
+
+  protected function getSitemapEntries()
+  {
+    return [];
   }
 }

--- a/src/views/sitemap-xml.blade.php
+++ b/src/views/sitemap-xml.blade.php
@@ -1,5 +1,5 @@
-{!! '<?xml version="1.0" encoding="utf-8"?>' !!}
-{!! '<?xml-stylesheet type="text/xsl" href="/sitemap.xsl"?>' !!}
+<{!! '?xml version="1.0" encoding="utf-8"?' !!}>
+<{!! '?xml-stylesheet type="text/xsl" href="/sitemap.xsl"?' !!}>
 <urlset xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
 @foreach ($entries as $entry)

--- a/src/views/sitemap-xsl.blade.php
+++ b/src/views/sitemap-xsl.blade.php
@@ -1,4 +1,4 @@
-{!! '<?xml version="1.0" encoding="UTF-8"?><xsl:stylesheet version="1.0" xmlns:html="http://www.w3.org/TR/REC-html40" xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">' !!}
+<{!! '?xml version="1.0" encoding="UTF-8"?><xsl:stylesheet version="1.0" xmlns:html="http://www.w3.org/TR/REC-html40" xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"' !!}>
 <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
 	<xsl:template match="/">
 		<html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
This bugfix fixed an issue that prevented the sitemap.xml template from rendering correctly in certain environments,.
It also adds a new overrideable method to the RouteServiceProvider `getSitemapEntries` that provides the entries to the sitemap.