### PR TITLE
Implement block name override

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -313,7 +313,12 @@ if (!function_exists('blocks')) {
   function blocks($area)
   {
     if ($page = current_page()) {
-      return $page->getBlocks($area);
+      return $page->getBlocks($area)->map(function($block) {
+          return [
+              config("blocks.overrides.{$block[0]}", $block[0]),
+              $block[1],
+          ];
+      });;
     }
 
     return collect([]);


### PR DESCRIPTION
This functionality is only really relevant for old sites that are being converted and has names that break PHP.

PHP class names can not start with a number, but some components in netflex sites being converted from the old framework does start with numbers.
This makes it impossible to use a Component class to house component logic as the class name resolved should start with a number, which as stated above is not valid PHP. 

This adds a simple config for overriding the block name supplied by Netflex in case it doesnt conform with Netflex.
