### PR TITLE
Add attributes to background-image

### DIFF
--- a/resources/views/background-image.blade.php
+++ b/resources/views/background-image.blade.php
@@ -67,7 +67,7 @@ $stack = $attributes->get('stack') ? $attributes->get('stack') : null;
 @endif
 
 @if($hasSlot)
-  <{{ $is }} class="{!! $class !!}">
+  <{{ $is }} class="{!! $class !!}" {!! $attributes->except(['stack', 'class'])->toHtml() !!}>
     {{ $slot }}
   </{{ $is }}>
 @endif


### PR DESCRIPTION
Allows for this component to for example be an `a` tag.

On my test setup, the normal `{{ $attributes }}` syntax did not work. Also I'm removing some spare attributes
