### PR TITLE
Update NavigationData.php

### DIFF
--- a/src/NavigationData.php
+++ b/src/NavigationData.php
@@ -122,7 +122,7 @@ class NavigationData implements JsonSerializable
           'target' => $target,
           'type' => $page->type,
           'title' => $page->nav_title ? $page->nav_title : $page->name,
-          'children' => navigation_data($page->id, $type, $root)
+          'children' => static::get($page->id, $type, $root)
         ]);
       };
 


### PR DESCRIPTION
The NavigationData class has an property that returns all child pages of a page as a list of NavigationData objects. 
But when extending the NavigationData class the children are still of the `Netflex\Pages\NavigationData` class, not the new extending class.

This PR fixes this inconsistency. Classes extending NavigationData will now return members of its own class instead of base class when accessing the children property